### PR TITLE
#58: get public charge comments via api

### DIFF
--- a/public-charge/docketsync/Dockerfile
+++ b/public-charge/docketsync/Dockerfile
@@ -1,0 +1,89 @@
+FROM ubuntu:bionic-20180526
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+# Install basic development & debugging tools
+RUN set -ex; \
+        \
+        apt-get update; \
+        apt-get install -y --no-install-recommends \
+            bash; \
+        \
+        rm -rf /var/lib/apt/lists/*;
+
+
+# Copy in Python package requirements files
+WORKDIR /tmp
+COPY Pipfile Pipfile
+COPY Pipfile.lock Pipfile.lock
+
+# Install build dependencies and Python packages
+# these build dependencies are only needed to compile
+# Python packages. After installing the packages,
+# purge them to keep the final layer small.
+RUN set -ex; \
+        \
+        buildDeps=" \
+            gcc \
+            git \
+            libc6-dev \
+            libffi-dev \
+            libssl-dev \
+        "; \
+        \
+        pythonPkgs=" \
+            python3 \
+            python3-dev \
+            python3-pip \
+        "; \
+        \
+        apt-get update; \
+        apt-get install -y $buildDeps $pythonPkgs --no-install-recommends; \
+        rm -rf /var/lib/apt/lists/*; \
+        \
+        ln -s /usr/bin/python3 /usr/bin/python; \
+        ln -s /usr/bin/pydoc3 /usr/bin/pydoc; \
+        \
+        python3 -m pip install --no-cache-dir setuptools; \
+        python3 -m pip install --no-cache-dir pipenv; \
+        pipenv lock -r > requirements.txt; \
+        python3 -m pip install --no-cache-dir -r requirements.txt; \
+        pipenv lock -r -d > requirements.txt; \
+        python3 -m pip install --no-cache-dir -r requirements.txt; \
+        rm -f requirements.txt Pipfile Pipfile.lock; \
+        \
+        apt-get purge -y --auto-remove $buildDeps;
+
+
+# Prevent python from creating .pyc files and __pycache__ dirs
+ENV PYTHONDONTWRITEBYTECODE=1
+
+
+# Show stdout when running in docker compose (dont buffer)
+ENV PYTHONUNBUFFERED=1
+
+
+# Add a python startup file
+COPY docker/pystartup /usr/local/share/python/pystartup
+ENV PYTHONSTARTUP=/usr/local/share/python/pystartup
+
+
+# command line setup
+# do minimal setup so we can be semi-efficient when using
+# the command line of the container. Without PS1, we will
+# get a prompt like "I have no name!@<container_id_hash>:/$"
+# since we don't create a user or group.
+RUN set -ex; \
+        echo "PS1='\h:\w\$ '" >> /etc/bash.bashrc; \
+        echo "alias ls='ls --color=auto'" >> /etc/bash.bashrc; \
+        echo "alias grep='grep --color=auto'" >> /etc/bash.bashrc;
+
+# setup a default command for running the container
+# avoid using ENTRYPOINT because we can't override it unless
+# we include an entrypoint script. we would want to override
+# ENTRYPOINT inside the Makefile shell and sync targets.
+COPY docketsync /usr/local/bin/docketsync
+CMD ["/usr/local/bin/docketsync", \
+     "--save-db", "comments.db", \
+     "--save-csv", "comments.csv"]

--- a/public-charge/docketsync/Makefile
+++ b/public-charge/docketsync/Makefile
@@ -1,0 +1,34 @@
+COMMAND=bash
+
+DATESTAMP:=`date --date="1 day ago" +'%Y-%m-%d'`
+
+DOCKER_COMMAND=docker run -it --rm --init \
+    --name docketsync-${TIMESTAMP} \
+    --user=`id -u`:`id -g` \
+    --volume ${CURDIR}:${WORKDIR} \
+    --workdir ${WORKDIR} \
+    --env REGULATIONS_GOV_API_KEY \
+    ${DOCKER_IMAGE}
+
+DOCKER_IMAGE=d4d/docketsync
+
+DOCKETSYNC_ARGS=\
+    --save-db comments_${DATESTAMP}.db \
+    --save-csv comments_${DATESTAMP}.csv \
+    --posted-date ${POSTED_DATE}
+
+POSTED_DATE:=`date --date="1 day ago" +'%m/%d/%y'`
+
+TIMESTAMP=`date +'%H%M%S'`
+
+WORKDIR=/opt/docketsync
+
+
+build:
+	docker build -t ${DOCKER_IMAGE} .
+
+shell:
+	${DOCKER_COMMAND} ${COMMAND}
+
+sync:
+	${DOCKER_COMMAND} ./docketsync ${DOCKETSYNC_ARGS}

--- a/public-charge/docketsync/Makefile
+++ b/public-charge/docketsync/Makefile
@@ -25,6 +25,7 @@ WORKDIR=/opt/docketsync
 
 
 build:
+	chmod 755 docketsync docketsync-run
 	docker build -t ${DOCKER_IMAGE} .
 
 shell:

--- a/public-charge/docketsync/Pipfile
+++ b/public-charge/docketsync/Pipfile
@@ -1,0 +1,13 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+pandas = "*"
+requests = "*"
+
+[requires]
+python_version = "3.6"

--- a/public-charge/docketsync/Pipfile
+++ b/public-charge/docketsync/Pipfile
@@ -1,13 +1,23 @@
 [[source]]
+
 name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 
+
 [dev-packages]
 
+pdbpp = "*"
+"flake8" = "*"
+ipython = "*"
+
+
 [packages]
+
 pandas = "*"
 requests = "*"
 
+
 [requires]
+
 python_version = "3.6"

--- a/public-charge/docketsync/Pipfile.lock
+++ b/public-charge/docketsync/Pipfile.lock
@@ -1,7 +1,20 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d538541d34fabfc784f0e86bf2187ce3c72d57f80b54ec06fcdac77cdb15b8b5"
+            "sha256": "d18f45556c603c1837f49e8ac82097a0bb64804c9d626098e2b8ee42bef50265"
+        },
+        "host-environment-markers": {
+            "implementation_name": "cpython",
+            "implementation_version": "3.6.4",
+            "os_name": "posix",
+            "platform_machine": "x86_64",
+            "platform_python_implementation": "CPython",
+            "platform_release": "4.15.0-39-generic",
+            "platform_system": "Linux",
+            "platform_version": "#42-Ubuntu SMP Tue Oct 23 15:48:01 UTC 2018",
+            "python_full_version": "3.6.4",
+            "python_version": "3.6",
+            "sys_platform": "linux"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -17,121 +30,150 @@
     },
     "default": {
         "certifi": {
-            "hashes": [
-                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
-                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
-            ],
+            "hashes": [],
             "version": "==2018.11.29"
         },
         "chardet": {
-            "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
-            ],
+            "hashes": [],
             "version": "==3.0.4"
         },
         "idna": {
-            "hashes": [
-                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
-                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
-            ],
+            "hashes": [],
             "version": "==2.7"
         },
         "numpy": {
-            "hashes": [
-                "sha256:0df89ca13c25eaa1621a3f09af4c8ba20da849692dcae184cb55e80952c453fb",
-                "sha256:154c35f195fd3e1fad2569930ca51907057ae35e03938f89a8aedae91dd1b7c7",
-                "sha256:18e84323cdb8de3325e741a7a8dd4a82db74fde363dce32b625324c7b32aa6d7",
-                "sha256:1e8956c37fc138d65ded2d96ab3949bd49038cc6e8a4494b1515b0ba88c91565",
-                "sha256:23557bdbca3ccbde3abaa12a6e82299bc92d2b9139011f8c16ca1bb8c75d1e95",
-                "sha256:24fd645a5e5d224aa6e39d93e4a722fafa9160154f296fd5ef9580191c755053",
-                "sha256:36e36b6868e4440760d4b9b44587ea1dc1f06532858d10abba98e851e154ca70",
-                "sha256:3d734559db35aa3697dadcea492a423118c5c55d176da2f3be9c98d4803fc2a7",
-                "sha256:416a2070acf3a2b5d586f9a6507bb97e33574df5bd7508ea970bbf4fc563fa52",
-                "sha256:4a22dc3f5221a644dfe4a63bf990052cc674ef12a157b1056969079985c92816",
-                "sha256:4d8d3e5aa6087490912c14a3c10fbdd380b40b421c13920ff468163bc50e016f",
-                "sha256:4f41fd159fba1245e1958a99d349df49c616b133636e0cf668f169bce2aeac2d",
-                "sha256:561ef098c50f91fbac2cc9305b68c915e9eb915a74d9038ecf8af274d748f76f",
-                "sha256:56994e14b386b5c0a9b875a76d22d707b315fa037affc7819cda08b6d0489756",
-                "sha256:73a1f2a529604c50c262179fcca59c87a05ff4614fe8a15c186934d84d09d9a5",
-                "sha256:7da99445fd890206bfcc7419f79871ba8e73d9d9e6b82fe09980bc5bb4efc35f",
-                "sha256:99d59e0bcadac4aa3280616591fb7bcd560e2218f5e31d5223a2e12a1425d495",
-                "sha256:a4cc09489843c70b22e8373ca3dfa52b3fab778b57cf81462f1203b0852e95e3",
-                "sha256:a61dc29cfca9831a03442a21d4b5fd77e3067beca4b5f81f1a89a04a71cf93fa",
-                "sha256:b1853df739b32fa913cc59ad9137caa9cc3d97ff871e2bbd89c2a2a1d4a69451",
-                "sha256:b1f44c335532c0581b77491b7715a871d0dd72e97487ac0f57337ccf3ab3469b",
-                "sha256:b261e0cb0d6faa8fd6863af26d30351fd2ffdb15b82e51e81e96b9e9e2e7ba16",
-                "sha256:c857ae5dba375ea26a6228f98c195fec0898a0fd91bcf0e8a0cae6d9faf3eca7",
-                "sha256:cf5bb4a7d53a71bb6a0144d31df784a973b36d8687d615ef6a7e9b1809917a9b",
-                "sha256:db9814ff0457b46f2e1d494c1efa4111ca089e08c8b983635ebffb9c1573361f",
-                "sha256:df04f4bad8a359daa2ff74f8108ea051670cafbca533bb2636c58b16e962989e",
-                "sha256:ecf81720934a0e18526177e645cbd6a8a21bb0ddc887ff9738de07a1df5c6b61",
-                "sha256:edfa6fba9157e0e3be0f40168eb142511012683ac3dc82420bee4a3f3981b30e"
-            ],
+            "hashes": [],
             "version": "==1.15.4"
         },
         "pandas": {
-            "hashes": [
-                "sha256:11975fad9edbdb55f1a560d96f91830e83e29bed6ad5ebf506abda09818eaf60",
-                "sha256:12e13d127ca1b585dd6f6840d3fe3fa6e46c36a6afe2dbc5cb0b57032c902e31",
-                "sha256:1c87fcb201e1e06f66e23a61a5fea9eeebfe7204a66d99df24600e3f05168051",
-                "sha256:242e9900de758e137304ad4b5663c2eff0d798c2c3b891250bd0bd97144579da",
-                "sha256:26c903d0ae1542890cb9abadb4adcb18f356b14c2df46e4ff657ae640e3ac9e7",
-                "sha256:2e1e88f9d3e5f107b65b59cd29f141995597b035d17cc5537e58142038942e1a",
-                "sha256:31b7a48b344c14691a8e92765d4023f88902ba3e96e2e4d0364d3453cdfd50db",
-                "sha256:4fd07a932b4352f8a8973761ab4e84f965bf81cc750fb38e04f01088ab901cb8",
-                "sha256:5b24ca47acf69222e82530e89111dd9d14f9b970ab2cd3a1c2c78f0c4fbba4f4",
-                "sha256:647b3b916cc8f6aeba240c8171be3ab799c3c1b2ea179a3be0bd2712c4237553",
-                "sha256:66b060946046ca27c0e03e9bec9bba3e0b918bafff84c425ca2cc2e157ce121e",
-                "sha256:6efa9fa6e1434141df8872d0fa4226fc301b17aacf37429193f9d70b426ea28f",
-                "sha256:be4715c9d8367e51dbe6bc6d05e205b1ae234f0dc5465931014aa1c4af44c1ba",
-                "sha256:bea90da782d8e945fccfc958585210d23de374fa9294a9481ed2abcef637ebfc",
-                "sha256:d318d77ab96f66a59e792a481e2701fba879e1a453aefeebdb17444fe204d1ed",
-                "sha256:d785fc08d6f4207437e900ffead930a61e634c5e4f980ba6d3dc03c9581748c7",
-                "sha256:de9559287c4fe8da56e8c3878d2374abc19d1ba2b807bfa7553e912a8e5ba87c",
-                "sha256:f4f98b190bb918ac0bc0e3dd2ab74ff3573da9f43106f6dba6385406912ec00f",
-                "sha256:f71f1a7e2d03758f6e957896ed696254e2bc83110ddbc6942018f1a232dd9dad",
-                "sha256:fb944c8f0b0ab5c1f7846c686bc4cdf8cde7224655c12edcd59d5212cd57bec0"
-            ],
-            "index": "pypi",
+            "hashes": [],
             "version": "==0.23.4"
         },
         "python-dateutil": {
-            "hashes": [
-                "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
-                "sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"
-            ],
+            "hashes": [],
             "version": "==2.7.5"
         },
         "pytz": {
-            "hashes": [
-                "sha256:31cb35c89bd7d333cd32c5f278fca91b523b0834369e757f4c5641ea252236ca",
-                "sha256:8e0f8568c118d3077b46be7d654cc8167fa916092e28320cde048e54bfc9f1e6"
-            ],
+            "hashes": [],
             "version": "==2018.7"
         },
         "requests": {
-            "hashes": [
-                "sha256:65b3a120e4329e33c9889db89c80976c5272f56ea92d3e74da8a463992e3ff54",
-                "sha256:ea881206e59f41dbd0bd445437d792e43906703fff75ca8ff43ccdb11f33f263"
-            ],
-            "index": "pypi",
+            "hashes": [],
             "version": "==2.20.1"
         },
         "six": {
-            "hashes": [
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
-            ],
+            "hashes": [],
             "version": "==1.11.0"
         },
         "urllib3": {
-            "hashes": [
-                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
-                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
-            ],
+            "hashes": [],
             "version": "==1.24.1"
         }
     },
-    "develop": {}
+    "develop": {
+        "backcall": {
+            "hashes": [],
+            "version": "==0.1.0"
+        },
+        "configparser": {
+            "hashes": [],
+            "markers": "python_version < '3.2'",
+            "version": "==3.5.0"
+        },
+        "decorator": {
+            "hashes": [],
+            "version": "==4.3.0"
+        },
+        "enum34": {
+            "hashes": [],
+            "markers": "python_version == '2.7'",
+            "version": "==1.1.6"
+        },
+        "fancycompleter": {
+            "hashes": [],
+            "version": "==0.8"
+        },
+        "flake8": {
+            "hashes": [],
+            "version": "==3.6.0"
+        },
+        "ipython": {
+            "hashes": [],
+            "version": "==7.2.0"
+        },
+        "ipython-genutils": {
+            "hashes": [],
+            "version": "==0.2.0"
+        },
+        "jedi": {
+            "hashes": [],
+            "version": "==0.13.1"
+        },
+        "mccabe": {
+            "hashes": [],
+            "version": "==0.6.1"
+        },
+        "parso": {
+            "hashes": [],
+            "version": "==0.3.1"
+        },
+        "pathlib2": {
+            "hashes": [],
+            "markers": "python_version in '2.6 2.7 3.2 3.3'",
+            "version": "==2.3.3"
+        },
+        "pdbpp": {
+            "hashes": [],
+            "version": "==0.9.3"
+        },
+        "pexpect": {
+            "hashes": [],
+            "version": "==4.6.0"
+        },
+        "pickleshare": {
+            "hashes": [],
+            "version": "==0.7.5"
+        },
+        "prompt-toolkit": {
+            "hashes": [],
+            "version": "==2.0.7"
+        },
+        "ptyprocess": {
+            "hashes": [],
+            "version": "==0.6.0"
+        },
+        "pycodestyle": {
+            "hashes": [],
+            "version": "==2.4.0"
+        },
+        "pyflakes": {
+            "hashes": [],
+            "version": "==2.0.0"
+        },
+        "pygments": {
+            "hashes": [],
+            "version": "==2.3.0"
+        },
+        "scandir": {
+            "hashes": [],
+            "markers": "python_version < '3.5'",
+            "version": "==1.9.0"
+        },
+        "six": {
+            "hashes": [],
+            "version": "==1.11.0"
+        },
+        "traitlets": {
+            "hashes": [],
+            "version": "==4.3.2"
+        },
+        "wcwidth": {
+            "hashes": [],
+            "version": "==0.1.7"
+        },
+        "wmctrl": {
+            "hashes": [],
+            "version": "==0.3"
+        }
+    }
 }

--- a/public-charge/docketsync/Pipfile.lock
+++ b/public-charge/docketsync/Pipfile.lock
@@ -1,0 +1,137 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "d538541d34fabfc784f0e86bf2187ce3c72d57f80b54ec06fcdac77cdb15b8b5"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.6"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
+                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+            ],
+            "version": "==2018.11.29"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
+                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
+            ],
+            "version": "==2.7"
+        },
+        "numpy": {
+            "hashes": [
+                "sha256:0df89ca13c25eaa1621a3f09af4c8ba20da849692dcae184cb55e80952c453fb",
+                "sha256:154c35f195fd3e1fad2569930ca51907057ae35e03938f89a8aedae91dd1b7c7",
+                "sha256:18e84323cdb8de3325e741a7a8dd4a82db74fde363dce32b625324c7b32aa6d7",
+                "sha256:1e8956c37fc138d65ded2d96ab3949bd49038cc6e8a4494b1515b0ba88c91565",
+                "sha256:23557bdbca3ccbde3abaa12a6e82299bc92d2b9139011f8c16ca1bb8c75d1e95",
+                "sha256:24fd645a5e5d224aa6e39d93e4a722fafa9160154f296fd5ef9580191c755053",
+                "sha256:36e36b6868e4440760d4b9b44587ea1dc1f06532858d10abba98e851e154ca70",
+                "sha256:3d734559db35aa3697dadcea492a423118c5c55d176da2f3be9c98d4803fc2a7",
+                "sha256:416a2070acf3a2b5d586f9a6507bb97e33574df5bd7508ea970bbf4fc563fa52",
+                "sha256:4a22dc3f5221a644dfe4a63bf990052cc674ef12a157b1056969079985c92816",
+                "sha256:4d8d3e5aa6087490912c14a3c10fbdd380b40b421c13920ff468163bc50e016f",
+                "sha256:4f41fd159fba1245e1958a99d349df49c616b133636e0cf668f169bce2aeac2d",
+                "sha256:561ef098c50f91fbac2cc9305b68c915e9eb915a74d9038ecf8af274d748f76f",
+                "sha256:56994e14b386b5c0a9b875a76d22d707b315fa037affc7819cda08b6d0489756",
+                "sha256:73a1f2a529604c50c262179fcca59c87a05ff4614fe8a15c186934d84d09d9a5",
+                "sha256:7da99445fd890206bfcc7419f79871ba8e73d9d9e6b82fe09980bc5bb4efc35f",
+                "sha256:99d59e0bcadac4aa3280616591fb7bcd560e2218f5e31d5223a2e12a1425d495",
+                "sha256:a4cc09489843c70b22e8373ca3dfa52b3fab778b57cf81462f1203b0852e95e3",
+                "sha256:a61dc29cfca9831a03442a21d4b5fd77e3067beca4b5f81f1a89a04a71cf93fa",
+                "sha256:b1853df739b32fa913cc59ad9137caa9cc3d97ff871e2bbd89c2a2a1d4a69451",
+                "sha256:b1f44c335532c0581b77491b7715a871d0dd72e97487ac0f57337ccf3ab3469b",
+                "sha256:b261e0cb0d6faa8fd6863af26d30351fd2ffdb15b82e51e81e96b9e9e2e7ba16",
+                "sha256:c857ae5dba375ea26a6228f98c195fec0898a0fd91bcf0e8a0cae6d9faf3eca7",
+                "sha256:cf5bb4a7d53a71bb6a0144d31df784a973b36d8687d615ef6a7e9b1809917a9b",
+                "sha256:db9814ff0457b46f2e1d494c1efa4111ca089e08c8b983635ebffb9c1573361f",
+                "sha256:df04f4bad8a359daa2ff74f8108ea051670cafbca533bb2636c58b16e962989e",
+                "sha256:ecf81720934a0e18526177e645cbd6a8a21bb0ddc887ff9738de07a1df5c6b61",
+                "sha256:edfa6fba9157e0e3be0f40168eb142511012683ac3dc82420bee4a3f3981b30e"
+            ],
+            "version": "==1.15.4"
+        },
+        "pandas": {
+            "hashes": [
+                "sha256:11975fad9edbdb55f1a560d96f91830e83e29bed6ad5ebf506abda09818eaf60",
+                "sha256:12e13d127ca1b585dd6f6840d3fe3fa6e46c36a6afe2dbc5cb0b57032c902e31",
+                "sha256:1c87fcb201e1e06f66e23a61a5fea9eeebfe7204a66d99df24600e3f05168051",
+                "sha256:242e9900de758e137304ad4b5663c2eff0d798c2c3b891250bd0bd97144579da",
+                "sha256:26c903d0ae1542890cb9abadb4adcb18f356b14c2df46e4ff657ae640e3ac9e7",
+                "sha256:2e1e88f9d3e5f107b65b59cd29f141995597b035d17cc5537e58142038942e1a",
+                "sha256:31b7a48b344c14691a8e92765d4023f88902ba3e96e2e4d0364d3453cdfd50db",
+                "sha256:4fd07a932b4352f8a8973761ab4e84f965bf81cc750fb38e04f01088ab901cb8",
+                "sha256:5b24ca47acf69222e82530e89111dd9d14f9b970ab2cd3a1c2c78f0c4fbba4f4",
+                "sha256:647b3b916cc8f6aeba240c8171be3ab799c3c1b2ea179a3be0bd2712c4237553",
+                "sha256:66b060946046ca27c0e03e9bec9bba3e0b918bafff84c425ca2cc2e157ce121e",
+                "sha256:6efa9fa6e1434141df8872d0fa4226fc301b17aacf37429193f9d70b426ea28f",
+                "sha256:be4715c9d8367e51dbe6bc6d05e205b1ae234f0dc5465931014aa1c4af44c1ba",
+                "sha256:bea90da782d8e945fccfc958585210d23de374fa9294a9481ed2abcef637ebfc",
+                "sha256:d318d77ab96f66a59e792a481e2701fba879e1a453aefeebdb17444fe204d1ed",
+                "sha256:d785fc08d6f4207437e900ffead930a61e634c5e4f980ba6d3dc03c9581748c7",
+                "sha256:de9559287c4fe8da56e8c3878d2374abc19d1ba2b807bfa7553e912a8e5ba87c",
+                "sha256:f4f98b190bb918ac0bc0e3dd2ab74ff3573da9f43106f6dba6385406912ec00f",
+                "sha256:f71f1a7e2d03758f6e957896ed696254e2bc83110ddbc6942018f1a232dd9dad",
+                "sha256:fb944c8f0b0ab5c1f7846c686bc4cdf8cde7224655c12edcd59d5212cd57bec0"
+            ],
+            "index": "pypi",
+            "version": "==0.23.4"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
+                "sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"
+            ],
+            "version": "==2.7.5"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:31cb35c89bd7d333cd32c5f278fca91b523b0834369e757f4c5641ea252236ca",
+                "sha256:8e0f8568c118d3077b46be7d654cc8167fa916092e28320cde048e54bfc9f1e6"
+            ],
+            "version": "==2018.7"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:65b3a120e4329e33c9889db89c80976c5272f56ea92d3e74da8a463992e3ff54",
+                "sha256:ea881206e59f41dbd0bd445437d792e43906703fff75ca8ff43ccdb11f33f263"
+            ],
+            "index": "pypi",
+            "version": "==2.20.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+            ],
+            "version": "==1.11.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
+                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+            ],
+            "version": "==1.24.1"
+        }
+    },
+    "develop": {}
+}

--- a/public-charge/docketsync/README.md
+++ b/public-charge/docketsync/README.md
@@ -84,8 +84,10 @@ run `docketsync` in the `d4d/docketsync` Docker container:
 * docker
 * API key from https://regulations.gov
 
-The `d4d/docketsync` Docker container has a pre-installed Python 3.6+
-interpreter and all of the packages necessary to run `docketsync`. The container also includes a copy of the `docketsync` program. You can build the Docker container by either using the `build` target in the Makefile:
+The `d4d/docketsync` Docker image has a pre-installed Python 3.6+ interpreter
+and all of the packages necessary to run `docketsync`. The image also
+includes a copy of the `docketsync` program. You can build the Docker image
+by either using the `build` target in the Makefile:
 
 ```
 make build

--- a/public-charge/docketsync/README.md
+++ b/public-charge/docketsync/README.md
@@ -1,24 +1,235 @@
 # DocketSync
 Download and synchronize comments from dockets on https://regulations.gov
 
-## Quick Start
+`docketsync` is a Python 3.6+ script that allows users to download comment
+metadata, text, and attachments from the https://regulations.gov website. With
+command line flags, users can specify the docket ID from which comments should
+be downloaded, filter by the date range that comments were posted to the
+website, and the file format that downloaded comments should be save to on
+local disk (SQLite database or CSV file).
 
-To run `docketsync`, you will need:
+## Getting Started
 
-* Python 3.6+
+The `docketsync` script can either be run from a local Python3 installation on
+your computer or from a Python3 installation in a Docker container running on
+your computer. The details below outline the steps necessary to get
+`docketsync` running using either of these two options. Before running the
+script, you will need to have an API key for the https://regulations.gov
+website and a local copy of this GitHub repository.
+
+### Setting up the API Key
+
+Save your https://regulations.gov API key to an environment variable named
+`REGULATIONS_GOV_API_KEY`.  See the [Getting an API Key](#Getting-an-API-Key)
+section for more details on how to get an API key.
+
+```
+export REGULATIONS_GOV_API_KEY="1234567890"
+```
+
+### Cloning the repository
+
+Make sure you also have a copy of this repository. You can get a copy by
+executing the following commands in your terminal.
+
+```
+git clone https://github.com/Data4Democracy/immigration-connect immigration-connect
+cd immigration-connect/public-charge;
+```
+
+### Option 1: Running `docketsync` with a local Python3 installation
+
+You will need to following commands and resources available on your system to
+run `docketsync` in your local Python3 installation:
+
+* bash
+* python 3.6+
 * pipenv
 * API key from https://regulations.gov
 
-```
-# setup your https://regulations.gov API key in an environment variable
-export REGULATIONS_GOV_API_KEY="1234567890"
+Use `pipenv` to setup a virtual environment with dependency Python packages and
+enter into the environment's shell.
 
+```
 # setup the virtual environment
 pipenv install
 
 # enter the virual environment
 pipenv shell
-
-# run the code
-./docketsync --save-db comments_2018-11-06_2018-11-06.db --save-csv comments_2018-11-06_2018-11-06.csv --posted_date 11/06/18
 ```
+
+Run `docketsync` from the command line:
+
+```
+./docketsync \
+  --save-db comments_2018-11-06.db \
+  --save-csv comments_2018-11-06.csv \
+  --posted_date 11/06/18
+```
+
+This command will produce 3 files and a directory:
+
+1. comments_2018-11-06.db - an SQLite database file with comment metadata and text
+2. comments_2018-11-06.csv - a comma separated value file with comment metadata and text
+3. comments.log - a docketsync log file
+4. attachments - a directory with files that were attached to the comment records.
+
+
+### Option 2: Running `docketsync` in a Docker container with `docketsync-run`
+
+You will need to following commands and resources available on your system to
+run `docketsync` in the `d4d/docketsync` Docker container:
+
+* bash
+* docker
+* API key from https://regulations.gov
+
+The `d4d/docketsync` Docker container has a pre-installed Python 3.6+
+interpreter and all of the packages necessary to run `docketsync`. The container also includes a copy of the `docketsync` program. You can build the Docker container by either using the `build` target in the Makefile:
+
+```
+make build
+```
+
+Or with the `docker build` command:
+
+```
+docker build -t d4d/docketsync .
+```
+
+The `docketsync-run` script contains all of the settings and commands necessary
+to run `docketsync` inside of the Docker image that was just built. The script
+accepts the same command line arguments as `docketsync`.
+
+Run `docketsync` inside of a Docker container with the following command:
+
+```
+./docketsync-run \
+  --save-db comments_2018-11-06.db \
+  --save-csv comments_2018-11-06.csv \
+  --posted_date 11/06/18
+```
+
+This command will produce 3 files and a directory:
+
+1. comments_2018-11-06.db - an SQLite database file with comment metadata and text
+2. comments_2018-11-06.csv - a comma separated value file with comment metadata and text
+3. comments.log - a docketsync log file
+4. attachments - a directory with files that were attached to the comment records.
+
+
+## Getting an API Key
+
+https://regulations.gov API keys allow users to access the website's HTTP API
+to retrieve data. At the time of writing, the API keys are based on
+https://data.gov API keys that have been authorized for use on the
+https://regulations.gov website. The authorization process involves:
+
+1. Registering for a https://data.gov website key, at
+   https://api.data.gov/signup/, with a business or education email address.
+   Gmail, Yahoo, and Outlook email addresses are not accepted by
+   https://regulations.gov.
+
+2. Send your API key to regulations@erulemakinghelpdesk.com asking for them to
+   authorize your API key for use on the https://regulations.gov website.
+
+
+## Common Usage Scenarios
+
+The scenarios listed below demonstrate common tasks that can be performed with
+the `docketsync` or `docketsync-run` commands. In the examples, the
+`docketsync` command will be used, for simplicity, but can just as easily be
+substituted with the `docketsync-run` command. Both commands accept the same
+flags.
+
+The default action of `docketsync` is to download comments, for docket id
+`USCIS-2010-0012`, that were posted to the website yesterday. There is no
+default save option, so either the `--save-db` or `--save-csv` flags will need
+to be set. If neither save flag is set, the results will not be saved.
+
+### List the `docketsync` help message and all of the flags
+
+```
+./docketsync --help
+```
+
+### Download comments posted yesterday, save to SQLite database
+
+Download comments, from docket id `USCIS-2010-0012` (the default docket id),
+posted to the website yesterday. Save comment metadata and text to an SQLite
+database named `comments.db`.
+
+```
+./docketsync --save-db comments.db
+```
+
+### Download comments from a specific docket id
+
+Download comments from docket id `CFTC-2018-0079-0001`, posted to the website
+yesterday. Save comment metadata and text to an SQLite database named
+`comments.db`.
+
+```
+./docketsync --docket CFTC-2018-0079-0001 --save-db comments.db
+```
+
+### Download comments posted yesterday, save to a comma separated value file
+
+Download comments posted to the website yesterday. Save comment metadata and
+text to a comma separated value file named `comments.csv`.
+
+```
+./docketsync --save-csv comments.csv
+```
+
+### Download comments posted on a specific date
+
+Download comments posted to the website on November 06, 2018. Save comment
+metadata and text to an SQLite database named `comments.db`.
+
+```
+./docketsync --save-db comments.db --posted-date 11/06/18
+```
+
+### Download comments posted within a specific date range
+
+Download comments posted to the website from November 01, 2018 through November
+30, 2018. Save comment metadata and text to an SQLite database named
+`comments.db`.
+
+```
+./docketsync --save-db comments.db --posted-date 11/01/18-11/30/18
+```
+
+### Load previously downloaded comments and download new comments
+
+Load an SQLite database file, named `comments_2018-11-01_2018-11-05.db`, that
+holds previously downloaded comment metadata and text, and download new
+comments posted to the website on November 06, 2018. Save the old and new
+comment metadata and text to an SQLite database named
+`comments_2018-11-01_2018-11-06.db`.
+
+```
+./docketsync \
+  --load-db comments_2018-11-01_2018-11-05.db \
+  --save-db comments_2018-11-01_2018-11-06.db \
+  --posted-date 11/06/18
+```
+
+### Load previously downloaded comments and check for missed comments
+
+Load an SQLite database file, named `comments_2018-11-01_2018-11-30.db`, that
+holds previously downloaded comment metadata and text, and check that all
+comments posted to the website from November 01, 2018 through November 30, 2018
+are captured in the database. Download only the comments missing from the
+database. Save the old and new comment metadata and text to an SQLite database
+named `comments_2018-11-01_2018-11-30.db`.
+
+```
+./docketsync \
+  --load-db comments_2018-11-01_2018-11-30.db \
+  --save-db comments_2018-11-01_2018-11-30.db \
+  --posted-date 11/01/18-11/30/18
+```
+
+

--- a/public-charge/docketsync/README.md
+++ b/public-charge/docketsync/README.md
@@ -37,6 +37,15 @@ git clone https://github.com/Data4Democracy/immigration-connect immigration-conn
 cd immigration-connect/public-charge;
 ```
 
+Ensure file permissions are properly set. Sometimes after doing a `git clone`,
+executable files don't have the proper file permissions. Use the following
+command to make sure the `docketsync` and `docketsync-run` scripts are
+executable.
+
+```
+chmod 755 docketsync docketsync-run
+```
+
 ### Option 1: Running `docketsync` with a local Python3 installation
 
 You will need to following commands and resources available on your system to

--- a/public-charge/docketsync/README.md
+++ b/public-charge/docketsync/README.md
@@ -73,7 +73,7 @@ Run `docketsync` from the command line:
 ./docketsync \
   --save-db comments_2018-11-06.db \
   --save-csv comments_2018-11-06.csv \
-  --posted_date 11/06/18
+  --posted-date 11/06/18
 ```
 
 This command will produce 3 files and a directory:
@@ -118,7 +118,7 @@ Run `docketsync` inside of a Docker container with the following command:
 ./docketsync-run \
   --save-db comments_2018-11-06.db \
   --save-csv comments_2018-11-06.csv \
-  --posted_date 11/06/18
+  --posted-date 11/06/18
 ```
 
 This command will produce 3 files and a directory:

--- a/public-charge/docketsync/README.md
+++ b/public-charge/docketsync/README.md
@@ -1,0 +1,24 @@
+# DocketSync
+Download and synchronize comments from dockets on https://regulations.gov
+
+## Quick Start
+
+To run `docketsync`, you will need:
+
+* Python 3.6+
+* pipenv
+* API key from https://regulations.gov
+
+```
+# setup your https://regulations.gov API key in an environment variable
+export REGULATIONS_GOV_API_KEY="1234567890"
+
+# setup the virtual environment
+pipenv install
+
+# enter the virual environment
+pipenv shell
+
+# run the code
+./docketsync --save-db comments_2018-11-06_2018-11-06.db --save-csv comments_2018-11-06_2018-11-06.csv --posted_date 11/06/18
+```

--- a/public-charge/docketsync/docker/pystartup
+++ b/public-charge/docketsync/docker/pystartup
@@ -1,0 +1,22 @@
+import readline
+import rlcompleter
+
+
+# setup readline and tab complete support for python 2 and 3
+
+readline.parse_and_bind('tab: complete')
+
+
+# disable python_history file inside of the container
+# else we will get the following error when exiting
+# and interactive session because there is no home dir:
+#
+# Error in atexit._run_exitfuncs:
+# PermissionError: [Errno 13] Permission denied
+#
+# https://unix.stackexchange.com/a/297834
+
+readline.write_history_file = lambda *args: None
+
+
+# vim: syntax=python

--- a/public-charge/docketsync/docketsync
+++ b/public-charge/docketsync/docketsync
@@ -450,9 +450,9 @@ def parse_arguments():
         type=int)
 
     parser.add_argument(
-        "--posted_date",
+        "--posted-date",
         help="date (or date range) comments were posted to reguolations.gov website. Format MM/DD/YY or MM/DD/YY-MM/DD/YY",
-        default="",
+        default=None,
         type=str)
 
     parser.add_argument(
@@ -493,10 +493,6 @@ if __name__ == '__main__' :
     # setup logging
     setup_logging(opts.logfile)
     log = logging.getLogger(__name__)
-
-    #logging.basicConfig(
-    #    format="%(asctime)s: %(message)s",
-    #    level=int((6-opts.verbose)*10))
 
     log.info('opts = {}'.format(opts))
 

--- a/public-charge/docketsync/docketsync
+++ b/public-charge/docketsync/docketsync
@@ -1,0 +1,541 @@
+#!/usr/bin/env python
+
+import argparse
+import datetime as dt
+import json
+import logging
+import os
+import pandas as pd
+import pathlib
+import sqlite3
+import textwrap
+import time
+import requests
+import urllib.parse
+
+
+class RegsGovAPIException(Exception):
+    def __init__(self, response):
+        self.response = response
+
+    def __repr__(self):
+        return '<RegsGovAPIException status=%s>' % self.response.status_code
+
+    def __str__(self):
+        req = self.response.request
+        return textwrap.dedent(
+                f'Failed to execute API request:\n\t{req.method} {req.url}'
+                f'\nBody:\n\t{req.body}'
+                f'\nResponse status code:\n\t{self.response.status_code}'
+                f'\nResponse body:\n\t{self.response.text}')
+
+
+class RegsGovAPI(object):
+
+    def __init__(self, key, base_url="https://api.data.gov:443/regulations/v3", delay=0):
+
+        self.base_url = base_url
+        self.key = key
+        self.delay = delay
+        self.calls = 0
+        self.session = requests.Session()
+        self.delay_end = dt.datetime.now()
+        self.log = logging.getLogger(__name__)
+        self.rate_limit_retry_delay = 120
+        self.server_error_retry_delay = 120
+
+    def request(self, method, path, **kwargs):
+
+        # increment for each api call
+        self.calls += 1
+
+        # if we have not met the delay timeout, wait for it to pass.
+        time_left = self.delay_end - dt.datetime.now()
+        if time_left.total_seconds() > 0:
+            # delay each api call
+            time.sleep(time_left.total_seconds())
+
+        # add the url to all outgoing requests.
+        path = f"{self.base_url}{path}"
+
+        # add an api key to all outgoing requests.
+        kwargs['params']['api_key'] = self.key
+
+        # make the request
+        response = method(path, **kwargs)
+
+        # if the response was error, check to see if it is an error we can
+        # handle. if not, raise an exception with info about the failed
+        # request.
+
+        # check for rate limit error
+        if response.status_code == 429:
+            # 429 indicates that we are making too many requests
+            # and we are over the rate limit
+            # we see this most often when downloading multiple files.
+            # wait for a bit and try the request again.
+            self.log.info("API request rate limit exceeded, retry in"
+                          f" {self.rate_limit_retry_delay} seconds.")
+            time.sleep(self.rate_limit_retry_delay)
+            retry_response = method(path, **kwargs)
+            if retry_response.status_code >= 400:
+                self.log.info("retry failed. raising original exception")
+                raise RegsGovAPIException(response)
+            else:
+                # save the retry response as the original response
+                response = retry_response
+
+        # client side error
+        if response.status_code >= 400 and response.status_code <= 499:
+            raise RegsGovAPIException(response)
+
+        # server side error
+        # try to handle server side hiccups by
+        # waiting 30 seconds and trying the request again
+        if response.status_code >= 500 and response.status_code <= 599:
+            self.log.info("received server error at"
+                          f" {response.request.url} {response.status_code}")
+            self.log.info("retrying request in"
+                          f" {self.server_error_retry_delay} seconds")
+            time.sleep(self.server_error_retry_delay)
+            retry_response = method(path, **kwargs)
+            if retry_response.status_code >= 400:
+                self.log.info("retry failed. raising original exception")
+                raise RegsGovAPIException(response)
+            else:
+                # save the retry response as the original response
+                response = retry_response
+
+        # set the next delay complete time
+        self.delay_end = dt.datetime.now() + dt.timedelta(seconds=self.delay)
+
+        return response
+
+    def documents(self, params):
+        method = self.session.get
+        path = "/documents.json"
+        response = self.request(method, path, params=params)
+        return response.json()
+
+    def document(self, params):
+        method = self.session.get
+        path = "/document.json"
+        response = self.request(method, path, params=params)
+        return response.json()
+
+    def dockets(self, params):
+        method = self.session.get
+        path = "/dockets.json"
+        response = self.request(method, path, params=params)
+        return response.json()
+
+    def download(self, params, filename):
+        method = self.session.get
+        path = "/download"
+        response = self.request(method, path, params=params, stream=True)
+
+        # save the file to disk
+        with open(filename,'wb') as fd:
+            chunk_cnt = 0
+            for chunk in response.iter_content(chunk_size=4096):
+                fd.write(chunk)
+                chunk_cnt += 1
+
+        return path
+
+
+class DocketSync(object):
+
+    def __init__(self, api_key, docket_id, attachments_dir="attachments",
+                 request_delay=0):
+
+        self.log = logging.getLogger(__name__)
+
+        self.docket_id = docket_id
+        self.attachments_dir = attachments_dir
+
+        # create an object that represents the regulations.gov api
+        self.api = RegsGovAPI(key=api_key, delay=request_delay)
+
+        # describe the dataframe that holds comments info
+        self.comments_column_names = [
+            'docid',
+            'tracking_number',
+            'rin',
+            'title',
+            'date_posted',
+            'date_received',
+            'comment_text',
+            'attachments'
+        ]
+
+        self.comments = pd.DataFrame(columns=self.comments_column_names)
+
+    def load_comments(self, load_from, table_name):
+
+        if os.path.exists(load_from) is False:
+            log.info(f"unable to load comments database {load_from}: does not exist")
+            return
+
+        # load a previously saved sqlite database
+        log.info(f"loading comments from {load_from}")
+        conn = sqlite3.connect(load_from)
+        self.comments = pd.read_sql(f"select * from {table_name};", conn)
+        conn.close()
+        log.info(f"loaded {len(self.comments.index)} comments")
+
+    def sync_comments(self, posted_date=None, records_per_page=1000,
+                      page_offset=0):
+
+        # make sure the attachments directory exists
+        pathlib.Path(self.attachments_dir).mkdir(parents=True, exist_ok=True)
+
+        # default posted date is yesterday
+        if posted_date is None:
+            posted_date= (
+                dt.datetime.now() - dt.timedelta(days=1)
+            ).strftime("%m/%d/%y")
+
+        self.log.info(f"using posted date: {posted_date}")
+
+        # track the number of records we have processed so far
+        # so we know how far through the process we are in
+        # log messages. this needs to be initialized to page_offset
+        # so the count is correct if we start at a page offset other
+        # than 0
+        record_cnt = page_offset
+
+        # traverse through all pages of comment document summaries
+        # start off by setting a temporary value in total_num_records
+        # make sure we run the while loop as least once to get the
+        # real total number of records.
+        total_num_records = page_offset + 1
+
+        while page_offset < total_num_records:
+
+            # retrieve summaries for all:
+            # public submission (comments) documents
+            # associated with our docket id
+            # posted between the date(s) in posted_date
+            # setting the number of records per page.
+            # for the current page offset
+            result = self.api.documents(params={
+                "dct": "PS",
+                "dktid": self.docket_id,
+                "pd": posted_date,
+                "rpp": records_per_page,
+                "po": page_offset,
+            })
+
+            self.log.info(f"processing comment summaries from"
+                          f" docket_id: {self.docket_id},"
+                          f" posted_date: {posted_date},"
+                          f" records_per_page: {records_per_page},"
+                          f" page_offset: {page_offset}")
+
+            # save the real total number of records
+            total_num_records = result['totalNumRecords']
+
+            self.log.info(f"total number of comments in query:"
+                          f" {total_num_records}")
+
+            # exit early if there are no records
+            # that is if the real total number of records is 0
+            # or if the json response has no 'documents' key
+            # in both cases, the json response has no 'documents' key
+            # so we only check for that condition to determine
+            # if there are records to parse.
+            if 'documents' not in result:
+                self.log.info(f"no more comment summary records to parse")
+                return
+
+            for record in result['documents']:
+
+                record_cnt += 1
+
+                # retrieve the comment's document id
+                docid = record['documentId']
+
+                # if we already have a record of this document
+                # continue on to the next document
+                if docid in self.comments.docid.values:
+                    # TODO: check if attachments exist on disk
+                    self.log.info(f"[{record_cnt}/{total_num_records}]"
+                                  f" skipping previously retrieved comment:"
+                                  f" {docid}")
+                    continue
+
+                self.log.info(f"[{record_cnt}/{total_num_records}]"
+                              f" retrieving {docid}")
+
+                # use the comment's document id to retrieve
+                # the full comment record
+                comment = self.api.document(params={"documentId": docid})
+
+                self._process_comment_record(comment)
+
+            # update the page offset to get the next page worth
+            # of comment summaries in the next while loop iteration
+            page_offset = page_offset + records_per_page
+
+    def _process_comment_record(self, comment):
+
+        data = dict.fromkeys(self.comments_column_names)
+
+        # store the comment's:
+
+        # document id
+        data['docid'] = comment['documentId']['value']
+
+        # title
+        # title include's the submitter's name but we don't parse
+        # out the submitter's name right now because it is not trivial
+        data['title'] = comment['title']['value']
+
+        # date posted
+        data['date_posted'] = comment['postedDate']
+
+        # tracking number
+        data['tracking_number'] = comment['trackingNumber']['value']
+
+        # RIN - regulation identification number
+        data['rin'] = comment['rin']['value']
+
+        # date received
+        data['date_received'] = comment['receivedDate']
+
+        # comment text
+        data['comment_text'] = comment['comment']['value']
+
+        data['attachments'] = []
+        # check the attachment count number (that is really a string)
+        if comment['attachmentCount']['value'] != "0":
+            # capture all attachments
+            for attachment in comment['attachments']:
+                data['attachments'].extend(
+                    self._get_comment_attachment(data['docid'], attachment))
+
+        # serialize the attachments list so it can be stored
+        # in a csv or sqlite db
+        data['attachments'] = " ".join(data['attachments'])
+
+        # save the data to the dataframe
+        self.comments.loc[len(self.comments)] = data
+
+    def _get_comment_attachment(self, docid, attachment):
+
+        # save the paths of all downloaded attachments
+        attachment_paths = []
+
+        # check if the attachment is downloadable by looking for an entry named
+        # 'fileFormats'. if there is no 'fileFormats' entry, it has probably
+        # been restricted and we can only capture the postingRestriction,
+        # reasonRestricted, and the title.
+        if 'fileFormats' not in attachment:
+            # not a downloadable attachment, save the metadata to a file
+            fname = "{0}_{1}.json".format(
+                docid,
+                attachment['attachmentOrderNumber'])
+
+            path = os.path.join(self.attachments_dir,fname)
+
+            with open(path,"w") as f:
+                json.dump(attachment, f, indent=2)
+
+            attachment_paths.append(path)
+
+            self.log.info(f"saved metadata to {path}")
+
+            # exit early, returning the attachment metadata file path
+            return attachment_paths
+
+        # fileFormats is a list of urls.
+        # download each file format,
+        # use query params to formulate the local filename
+        for attachment_full_uri in attachment['fileFormats']:
+
+            # separate the scheme, netloc, and path
+            # from the query parameters
+            parsed_uri = urllib.parse.urlparse(attachment_full_uri)
+
+            # parse the query params into a dictionary
+            query_params = dict(urllib.parse.parse_qsl(parsed_uri.query))
+
+            # generate the filename based on query params
+            fname = "{0}_{1}.{2}".format(
+                query_params['documentId'],
+                query_params['attachmentNumber'],
+                query_params['contentType'])
+
+            path = os.path.join(self.attachments_dir,fname)
+
+            # make request and download file data
+            self.api.download(params=query_params, filename=path)
+            self.log.info(f"downloaded {path}")
+
+            attachment_paths.append(path)
+
+        # return downloaded file paths
+        return attachment_paths
+
+def save_as_csv(opts, df):
+    # save as csv file
+    df.to_csv(opts.save_csv, index=False)
+
+def save_as_sqlite(opts, df):
+    # save as sqlit3 database
+    # make docid an index in the database
+    conn = sqlite3.connect(opts.save_db)
+    df.to_sql(opts.comments_table, conn, if_exists='replace', index=False)
+    conn.close()
+
+def setup_logging(logfile_name):
+
+    # log to file
+    logging.basicConfig(
+            level=logging.DEBUG,
+            format='%(asctime)s %(name)-25s %(levelname)-8s %(message)s',
+            datefmt='%Y-%m-%d %H:%M:%S',
+            filename=logfile_name,
+            filemode='a')
+
+    # define a Handler which writes INFO messages or higher to the sys.stderr
+    console = logging.StreamHandler()
+    console.setLevel(logging.INFO)
+    # setup a format for the console logger
+    formatter = logging.Formatter(fmt='%(asctime)s %(message)s',
+                                  datefmt='%Y-%m-%d %H:%M:%S')
+    console.setFormatter(formatter)
+    # add the new handler to the root logger
+    logging.getLogger('').addHandler(console)
+
+def parse_arguments():
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--attachments-dir",
+        help="directory holding attachments",
+        default="attachments",
+        type=str)
+
+    parser.add_argument(
+        "--comments-table",
+        help="name of the sql db table holding comments",
+        default="comments",
+        type=str)
+
+    parser.add_argument(
+        "--docket",
+        help="docket id to retrieve data from",
+        default="USCIS-2010-0012",
+        type=str)
+
+    parser.add_argument(
+        "--load-db",
+        help="load comments data from the named sqlite file",
+        default=None,
+        type=str)
+
+    parser.add_argument(
+        "--logfile",
+        help="name of logfile to write log messages to",
+        default="comments.log",
+        type=str)
+
+    parser.add_argument(
+        "--page-offset",
+        help="page offset for /documents endpoint",
+        default=0,
+        type=int)
+
+    parser.add_argument(
+        "--posted_date",
+        help="date (or date range) comments were posted to reguolations.gov website. Format MM/DD/YY or MM/DD/YY-MM/DD/YY",
+        default="",
+        type=str)
+
+    parser.add_argument(
+        "--records-per-page",
+        help="max number of records a request to /documents endpoint should return",
+        default=1000,
+        type=int)
+
+    parser.add_argument(
+        "--request-delay",
+        help="minimum number of seconds between api requests",
+        default=4,
+        type=int)
+
+    parser.add_argument(
+        "--save-csv",
+        help="save the data to the named csv file",
+        default=None,
+        type=str)
+
+    parser.add_argument(
+        "--save-db",
+        help="save the data to the named sqlite file",
+        default=None,
+        type=str)
+
+    opts = parser.parse_args()
+    return opts
+
+
+if __name__ == '__main__' :
+
+    opts = parse_arguments()
+
+    # read in the API key from the REGULATIONS_GOV_API_KEY environment variable
+    API_KEY = os.environ['REGULATIONS_GOV_API_KEY']
+
+    # setup logging
+    setup_logging(opts.logfile)
+    log = logging.getLogger(__name__)
+
+    #logging.basicConfig(
+    #    format="%(asctime)s: %(message)s",
+    #    level=int((6-opts.verbose)*10))
+
+    log.info('opts = {}'.format(opts))
+
+    # capture time before we start querying
+    start_time = dt.datetime.now()
+
+    try:
+        ds = DocketSync(
+                API_KEY,
+                opts.docket,
+                attachments_dir=opts.attachments_dir,
+                request_delay=opts.request_delay)
+
+        # load comments from the database
+        if opts.load_db is not None:
+            ds.load_comments(
+                load_from=opts.load_db,
+                table_name=opts.comments_table)
+
+        # retrieve new comments
+        ds.sync_comments(
+            posted_date=opts.posted_date,
+            records_per_page=opts.records_per_page,
+            page_offset=opts.page_offset)
+
+    finally:
+        # capture time when we finish querying
+        end_time = dt.datetime.now()
+        elapsed_time = end_time - start_time
+
+        log.info(f"made {ds.api.calls} API call(s) in {elapsed_time}")
+
+        if opts.save_csv is not None:
+            log.info(f"saving comments to {opts.save_csv}")
+            save_as_csv(opts, ds.comments)
+
+        if opts.save_db is not None:
+            log.info(f"saving comments to {opts.save_db}")
+            save_as_sqlite(opts, ds.comments)
+
+        log.info('exiting')
+

--- a/public-charge/docketsync/docketsync-run
+++ b/public-charge/docketsync/docketsync-run
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# declare constants
+DOCKER_IMAGE=d4d/docketsync
+DOCKETSYNC_PATH=/usr/local/bin/docketsync
+TIMESTAMP=`date +'%H%M%S'`
+WORKDIR=/opt/docketsync
+
+# if there are any arguments,
+# pass them along to the Docker command
+if [ "$#" -gt 0 ]; then
+    docketsync_cmd="${DOCKETSYNC_PATH} $*"
+else
+    docketsync_cmd=
+fi
+
+# launch docketsync inside a Docker container
+docker run -it --rm --init \
+    --name docketsync-${TIMESTAMP} \
+    --user=`id -u`:`id -g` \
+    --volume `pwd`:${WORKDIR} \
+    --workdir ${WORKDIR} \
+    --env REGULATIONS_GOV_API_KEY \
+    ${DOCKER_IMAGE} \
+    ${docketsync_cmd}


### PR DESCRIPTION
This PR introduces a Python3 based script, named `docketsync`, that can be used to download comments from a docket on the regulations.gov website. Comments are discovered and downloaded through the https://regulations.gov website's public HTTP API. Use of the API requires that the caller gets an API key. The downloaded comments can be saved as an SQLite database or CSV file. 

The README.md file describes how to get started using `docketsync` and the complementary `docketsync-run`, which runs `docketsync` in a Docker container.

Connected to #58 